### PR TITLE
Fix Source code Layer.prototype.url @example

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -103,7 +103,7 @@ Layer.prototype.captures = function (path) {
  * @example
  *
  * ```javascript
- * var route = new Layer(['GET'], '/users/:id', fn);
+ * var route = new Layer('/users/:id', ['GET'], fn);
  *
  * route.url({ id: 123 }); // => "/users/123"
  * ```


### PR DESCRIPTION
Hi
    Now I learning koa-router source code, i find Layer.prototype.url @example  looks different from the test/layer.js
    Maybe it should be changed here.
    @alexmingoia 