### PR TITLE
Use longest match for ctx._matchedRoute, fixes #478

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -44,21 +44,28 @@ function Layer(path, methods, middleware, opts) {
   }, this);
 
   this.path = path;
+  this.plainPath = path instanceof RegExp ? path.source :
+                                            path.replace(/\(\.\*\)/g, '');
+
   this.regexp = pathToRegExp(path, this.paramNames, this.opts);
+  this.regexp = new RegExp(this.regexp.source, 'gi');
 
   debug('defined route %s %s', this.methods, this.opts.prefix + this.path);
 };
 
 /**
- * Returns whether request `path` matches route.
+ * Returns the length of given `path` that matches route, or -1 if no match.
  *
  * @param {String} path
- * @returns {Boolean}
+ * @returns {number}
  * @private
  */
 
-Layer.prototype.match = function (path) {
-  return this.regexp.test(path);
+Layer.prototype.matchLength = function (path) {
+  var result = this.regexp.test(path);
+  var lastIndex = this.regexp.lastIndex;
+  this.regexp.lastIndex = 0;
+  return result ? lastIndex : -1;
 };
 
 /**
@@ -94,7 +101,9 @@ Layer.prototype.params = function (path, captures, existingParams) {
 
 Layer.prototype.captures = function (path) {
   if (this.opts.ignoreCaptures) return [];
-  return path.match(this.regexp).slice(1);
+  var result = this.regexp.exec(path).slice(1);
+  this.regexp.lastIndex = 0;
+  return result;
 };
 
 /**
@@ -115,8 +124,7 @@ Layer.prototype.captures = function (path) {
 
 Layer.prototype.url = function (params, options) {
   var args = params;
-  var url = this.path.replace(/\(\.\*\)/g, '');
-  var toPath = pathToRegExp.compile(url);
+  var toPath = pathToRegExp.compile(this.plainPath);
   var replaced;
 
   if (typeof params != 'object') {
@@ -127,7 +135,7 @@ Layer.prototype.url = function (params, options) {
     }
   }
 
-  var tokens = pathToRegExp.parse(url);
+  var tokens = pathToRegExp.parse(this.plainPath);
   var replace = {};
 
   if (args instanceof Array) {
@@ -214,8 +222,10 @@ Layer.prototype.param = function (param, fn) {
 Layer.prototype.setPrefix = function (prefix) {
   if (this.path) {
     this.path = prefix + this.path;
+    this.plainPath = this.path.replace(/\(\.\*\)/g, '');
     this.paramNames = [];
     this.regexp = pathToRegExp(this.path, this.paramNames, this.opts);
+    this.regexp = new RegExp(this.regexp.source, 'gi');
   }
 
   return this;

--- a/lib/router.js
+++ b/lib/router.js
@@ -332,7 +332,7 @@ Router.prototype.routes = Router.prototype.middleware = function () {
     if (!matched.route) return next();
 
     var matchedLayers = matched.pathAndMethod
-    var mostSpecificLayer = matchedLayers[matchedLayers.length - 1]
+    var mostSpecificLayer = matched.longestMatch;
     ctx._matchedRoute = mostSpecificLayer.path;
     if (mostSpecificLayer.name) {
       ctx._matchedRouteName = mostSpecificLayer.name;
@@ -651,21 +651,36 @@ Router.prototype.url = function (name, params) {
 Router.prototype.match = function (path, method) {
   var layers = this.stack;
   var layer;
+  var maxMatchLength = -1;
+  var maxMatchPathLength = -1;
   var matched = {
     path: [],
     pathAndMethod: [],
-    route: false
+    route: false,
+    longestMatch: null
   };
 
   for (var len = layers.length, i = 0; i < len; i++) {
     layer = layers[i];
 
     debug('test %s %s', layer.path, layer.regexp);
+    var matchLength = layer.matchLength(path);
 
-    if (layer.match(path)) {
+    if (~matchLength) {
       matched.path.push(layer);
 
       if (layer.methods.length === 0 || ~layer.methods.indexOf(method)) {
+        var matchPathLength = layer.plainPath.length;
+        if (matchLength > maxMatchLength) {
+          maxMatchLength = matchLength;
+          maxMatchPathLength = matchPathLength;
+          matched.longestMatch = layer;
+        } else if (matchLength === maxMatchLength &&
+                   matchPathLength >= maxMatchPathLength) {
+          // tiebreak based on pattern length
+          maxMatchPathLength = matchPathLength;
+          matched.longestMatch = layer;
+        }
         matched.pathAndMethod.push(layer);
         if (layer.methods.length) matched.route = true;
       }
@@ -728,6 +743,6 @@ Router.prototype.param = function (param, middleware) {
  * @returns {String}
  */
 Router.url = function (path, params) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    return Layer.prototype.url.apply({ path: path }, args);
+  var args = Array.prototype.slice.call(arguments, 1);
+  return Layer.prototype.url.apply({ plainPath: path }, args);
 };

--- a/test/lib/layer.js
+++ b/test/lib/layer.js
@@ -10,7 +10,7 @@ var Koa = require('koa')
   , Layer = require('../../lib/layer');
 
 describe('Layer', function() {
-  it('composes multiple callbacks/middlware', function(done) {
+  it('composes multiple callbacks/middleware', function(done) {
     var app = new Koa();
     var router = new Router();
     app.use(router.routes());
@@ -34,7 +34,7 @@ describe('Layer', function() {
     });
   });
 
-  describe('Layer#match()', function() {
+  describe('Layer#matchLength()', function() {
     it('captures URL path parameters', function(done) {
       var app = new Koa();
       var router = new Router();


### PR DESCRIPTION
Fixes #478 by using the longest path, or the length of path string as a tiebreaker to determine "most specific layer"

I tried to implement it without replacing RegExp.prototype.test with something that like RegExp.prototype.exec which returns more match information, as that would decrease routing performance.

This does subtly change the behavior of koa-router, though. Is 5.x release planned soon, and will it fix #478 ?